### PR TITLE
Add device selector in dashboard apps.

### DIFF
--- a/dashboard/app.go
+++ b/dashboard/app.go
@@ -143,6 +143,7 @@ func settingHandler(w http.ResponseWriter, r *http.Request) {
 	if setting.Period == "" {
 		setting.Period = DefaultPeriod
 	}
+	setting.DeviceId = r.FormValue("deviceId")
 	if setting.DeviceId == "" {
 		setting.DeviceId = DefaultDeviceId
 	}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -18,6 +18,14 @@
     <form class="header-box" name="form" action="/setting" method="post">
         <div class="control">
           <div class="select is-small is-info is-rounded">
+            <select name="deviceId" id="deviceId">
+              <option value="picamera01" selected>camera1</option>
+              <option value="picamera02">camera2</option>
+            </select>
+          </div>
+        </div>
+        <div class="control">
+          <div class="select is-small is-info is-rounded">
             <select name="season" id="season">
               <option value="spring" {{if eq .Setting.Season "spring"}}selected{{end}}>Spring</option>
               <option value="summer" {{if eq .Setting.Season "summer"}}selected{{end}}>Summer</option>
@@ -46,7 +54,7 @@
             <i class="material-icons camera" title="camera">linked_camera</i>
           </span>
           <div>
-            <img id="src_image" src="https://storage.googleapis.com/gcp-iost-images/annotated/picamera01/annotated.jpg" />
+            <img id="src_image" src="https://storage.googleapis.com/gcp-iost-images/annotated/{{.Setting.DeviceId}}/annotated.jpg" />
           </div>
           <div class="content-footer">&nbsp;</div>
           </div>

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -46,7 +46,7 @@ $(function() {
 
 function updateSrcImg() {
   console.log(new Date(), 'Get input image');
-  src = "https://storage.googleapis.com/gcp-iost-images/annotated/" + $('#deviceId').val() + "/annotated.jpg"
+  var src = "https://storage.googleapis.com/gcp-iost-images/annotated/" + $('#deviceId').val() + "/annotated.jpg"
   $('#src_image').attr('src', src + '?' + new Date().getTime());
 }
 

--- a/dashboard/static/js/main.js
+++ b/dashboard/static/js/main.js
@@ -13,6 +13,7 @@ $(function() {
   $('select').change(function(e) {
     disableForm();
     let data = new FormData();
+    data.append('deviceId', $('#deviceId').val());
     data.append('season', $('#season').val());
     data.append('period', $('#period').val());
     $.ajax({
@@ -24,6 +25,8 @@ $(function() {
       contentType: false,
     }).done(function(data, textStatus) {
       console.log(new Date(), 'Submission was successful.');
+      updateSrcImg();
+      updateResult();
     }).fail(function(xhr, textStatus, errorThrown) {
       console.error(new Date(), 'An error occurred.', textStatus);
     }).always(function() {
@@ -43,7 +46,7 @@ $(function() {
 
 function updateSrcImg() {
   console.log(new Date(), 'Get input image');
-  const src = $('#src_image').attr('src');
+  src = "https://storage.googleapis.com/gcp-iost-images/annotated/" + $('#deviceId').val() + "/annotated.jpg"
   $('#src_image').attr('src', src + '?' + new Date().getTime());
 }
 
@@ -51,7 +54,7 @@ function updateResult() {
   console.log(new Date(), 'Get result image');
   $.ajax({
     url: '/displayByDevice',
-    data: {deivceId: "picamera01"},
+    data: {deivceId: $('#deviceId').val()},
     dataType: 'html',
     cache: false,
   }).done(function(data, textStatus) {


### PR DESCRIPTION
Add select box for `deviceId` settings.
Source image and result display should follow the setting of deviceId.
So I add `updateSrcImg()` and `updateResult()` in the callback of `POST /setting` request.
